### PR TITLE
Band Selection mismatch in APA visualization

### DIFF
--- a/app/algorithms/visualizations/apa.py
+++ b/app/algorithms/visualizations/apa.py
@@ -2,7 +2,7 @@
 def apa_viridis_visualization(data):
     """
     Apply viridis colormap to FAI values
-    Input data array: [B02, B03, B04, B05, B07, B8A, B11, B12]
+    Input data array: [B02, B03, B04, B05, B08, B8A, B11]
     """
     B02, B03, B04, B05, B08, B8A, B11 = (
         data[0],

--- a/app/config/sample-scenes.ts
+++ b/app/config/sample-scenes.ts
@@ -31,7 +31,7 @@ export const SAMPLE_SCENES: SampleScene[] = [
       'https://api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a/items/S2B_MSIL2A_20251123T101239_N0511_R022_T32TQR_20251123T105704',
     collectionId: 'sentinel-2-l2a',
     suggestedAlgorithm: apaAlgorithm,
-    defaultBands: ['b02', 'b03', 'b04', 'b05', 'b07', 'b08', 'b8a', 'b11'], // Bands useful for APA
+    defaultBands: ['b02', 'b03', 'b04', 'b05', 'b08', 'b8a', 'b11'], // Bands useful for APA
     temporalRange: ['2025-05-12', '2025-05-13'],
     parameterDefaults: {
       boundingBox: [12.0, 44.5, 14.0, 46.0], // west, south, east, north for Venice area


### PR DESCRIPTION
This fixes the band positions which didn't match their usage,
causing incorrect calculations in the APA visualization.

This fix reveals critical UX problem with the current band selection approach.

```python
# Current (fragile):
B02, B03, B04 = data[0], data[1], data[2]  # Hope the order is right!
```

It relies on **positional array access** which creates a fragile implicit contract:

1. **Band selection in UI** → `selectedBands` array order
2. **Python code** → positional `data[n]` access
3. **No validation** that these match

This would silently produce incorrect results with no error messages.

I am wondering: Instead of positional arrays, could we use **named band access**?

```python
# Proposed (explicit):
B02 = data.band('b02')
B03 = data.band('b03')
B04 = data.band('b04')
```

Would this approach be compatible with the current OpenEO Parameter architecture and `apply_dimension` pattern? Could we achieve it with refactoring of loader.py?

## Alternative: UI Improvements

If named access isn't feasible, we could improve the current approach with:

1. Visual band mapping display (`data[0] → b02 (Blue)`) – already WIP by @ricardoduplos
2. Auto-generated unpacking snippets ?
3. Static analysis to catch mismatches ?
4. Runtime validation helpers ?

Thoughts? @emmanuelmathot @j08lue