### PR TITLE
Implements React Router for navigation

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -1,19 +1,11 @@
-import { useEffect } from 'react';
 import { Flex } from '@chakra-ui/react';
 import { Route, Routes } from 'react-router';
 import { AppHeader } from '$components/layout/app-header';
 import { LandingPage } from '$pages/landing-page';
 import { EditorPage } from '$pages/editor-page';
 import UhOh404 from '$pages/uhoh/404';
-import { useSceneValues } from './stores/scene/selectors';
 
 export default function App() {
-  const [, reset] = useSceneValues();
-
-  useEffect(() => {
-    reset();
-  }, []);
-
   return (
     <Flex flexDirection='column' height='100vh'>
       <AppHeader />

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -1,56 +1,27 @@
-import { useState } from 'react';
+import { useEffect } from 'react';
 import { Flex } from '@chakra-ui/react';
+import { Route, Routes } from 'react-router';
 import { AppHeader } from '$components/layout/app-header';
 import { LandingPage } from '$pages/landing-page';
 import { EditorPage } from '$pages/editor-page';
-import { getSceneById, BLANK_SCENE_ID } from './config/sample-scenes';
+import UhOh404 from '$pages/uhoh/404';
+import { useSceneValues } from './stores/scene/selectors';
 
 export default function App() {
-  const [selectedSceneId, setSelectedSceneId] = useState<string | null>(null);
-  const [blankSceneConfig, setBlankSceneConfig] = useState<{
-    collectionId: string;
-    temporalRange: [string, string];
-    cloudCover: number;
-  } | null>(null);
+  const [, reset] = useSceneValues();
 
-  // Get the selected scene data
-  let scene = selectedSceneId ? getSceneById(selectedSceneId) : null;
-
-  // If it's a blank scene, override defaults with the configured values
-  if (scene && scene.id === BLANK_SCENE_ID && blankSceneConfig) {
-    scene = {
-      ...scene,
-      collectionId: blankSceneConfig.collectionId,
-      temporalRange: blankSceneConfig.temporalRange,
-      cloudCover: blankSceneConfig.cloudCover
-    };
-  }
-
-  // If scene not found but ID is set, reset
-  if (selectedSceneId && !scene) {
-    setSelectedSceneId(null);
-  }
-
-  const handleStartFromScratch = (config: {
-    collectionId: string;
-    temporalRange: [string, string];
-    cloudCover: number;
-  }) => {
-    setBlankSceneConfig(config);
-    setSelectedSceneId(BLANK_SCENE_ID);
-  };
+  useEffect(() => {
+    reset();
+  }, []);
 
   return (
     <Flex flexDirection='column' height='100vh'>
       <AppHeader />
-      {!selectedSceneId ? (
-        <LandingPage
-          onSelectScene={setSelectedSceneId}
-          onStartFromScratch={handleStartFromScratch}
-        />
-      ) : scene ? (
-        <EditorPage scene={scene} onBack={() => setSelectedSceneId(null)} />
-      ) : null}
+      <Routes>
+        <Route path='/' element={<LandingPage />} />
+        <Route path='/editor/:sceneId' element={<EditorPage />} />
+        <Route path='*' element={<UhOh404 />} />
+      </Routes>
     </Flex>
   );
 }

--- a/app/components/common/smart-link.tsx
+++ b/app/components/common/smart-link.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react';
+import { Link as ChLink, LinkProps } from '@chakra-ui/react';
+import { Link, To } from 'react-router';
+
+export interface SmartLinkProps extends LinkProps {
+  to: To;
+}
+
+export default forwardRef<HTMLAnchorElement, SmartLinkProps>(
+  function SmartLink(props, ref) {
+    const { to, children, ...rest } = props;
+
+    const isExternal =
+      typeof to === 'string' &&
+      (to.match(/^(https?:)?\/\//) || to.match(/^(mailto|tel):/));
+
+    return isExternal ? (
+      <ChLink ref={ref} href={to} {...rest}>
+        {children}
+      </ChLink>
+    ) : (
+      <ChLink ref={ref} asChild {...rest}>
+        <Link to={to}>{children}</Link>
+      </ChLink>
+    );
+  }
+);

--- a/app/components/landing/scene-card.tsx
+++ b/app/components/landing/scene-card.tsx
@@ -9,13 +9,13 @@ import {
 } from '@chakra-ui/react';
 import { useCollection } from '@developmentseed/stac-react';
 import { SampleScene } from '$types';
+import SmartLink from '$components/common/smart-link';
 
 interface SceneCardProps {
   scene: SampleScene;
-  onSelect: (sceneId: string) => void;
 }
 
-export function SceneCard({ scene, onSelect }: SceneCardProps) {
+export function SceneCard({ scene }: SceneCardProps) {
   const { collection, isLoading } = useCollection(scene.collectionId);
 
   // Extract thumbnail from STAC item assets
@@ -23,62 +23,64 @@ export function SceneCard({ scene, onSelect }: SceneCardProps) {
 
   return (
     <Card.Root
-      onClick={() => onSelect(scene.id)}
       cursor='pointer'
+      asChild
       transition='all 0.2s'
       _hover={{
         transform: 'translateY(-4px)',
         shadow: 'lg'
       }}
     >
-      <Card.Body gap={4}>
-        {/* Thumbnail */}
-        {isLoading ? (
-          <Box
-            height='200px'
-            width='100%'
-            bg='gray.100'
-            borderRadius='md'
-            display='flex'
-            alignItems='center'
-            justifyContent='center'
-          >
-            <Spinner size='lg' />
-          </Box>
-        ) : thumbnail ? (
-          <Image
-            src={thumbnail}
-            alt={scene.name}
-            height='200px'
-            width='100%'
-            objectFit='cover'
-            borderRadius='md'
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-            }}
-          />
-        ) : (
-          <Box
-            height='200px'
-            width='100%'
-            bg='gray.200'
-            borderRadius='md'
-            display='flex'
-            alignItems='center'
-            justifyContent='center'
-          >
-            <Text color='gray.500'>No Preview</Text>
-          </Box>
-        )}
+      <SmartLink to={`/editor/${scene.id}`} unstyled>
+        <Card.Body gap={4}>
+          {/* Thumbnail */}
+          {isLoading ? (
+            <Box
+              height='200px'
+              width='100%'
+              bg='gray.100'
+              borderRadius='md'
+              display='flex'
+              alignItems='center'
+              justifyContent='center'
+            >
+              <Spinner size='lg' />
+            </Box>
+          ) : thumbnail ? (
+            <Image
+              src={thumbnail}
+              alt={scene.name}
+              height='200px'
+              width='100%'
+              objectFit='cover'
+              borderRadius='md'
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
+            />
+          ) : (
+            <Box
+              height='200px'
+              width='100%'
+              bg='gray.200'
+              borderRadius='md'
+              display='flex'
+              alignItems='center'
+              justifyContent='center'
+            >
+              <Text color='gray.500'>No Preview</Text>
+            </Box>
+          )}
 
-        {/* Scene info */}
-        <Flex flexDirection='column' gap={2}>
-          <Heading size='md'>{scene.name}</Heading>
-          <Text fontSize='sm' color='gray.600'>
-            {scene.description}
-          </Text>
-        </Flex>
-      </Card.Body>
+          {/* Scene info */}
+          <Flex flexDirection='column' gap={2}>
+            <Heading size='md'>{scene.name}</Heading>
+            <Text fontSize='sm' color='gray.600'>
+              {scene.description}
+            </Text>
+          </Flex>
+        </Card.Body>
+      </SmartLink>
     </Card.Root>
   );
 }

--- a/app/components/landing/scene-grid.tsx
+++ b/app/components/landing/scene-grid.tsx
@@ -6,19 +6,15 @@ import { SceneCard } from './scene-card';
 import { BlankCard } from './blank-card';
 
 interface SceneGridProps {
-  onSelectScene: (sceneId: string) => void;
   onBlankSceneClick: () => void;
 }
 
-export function SceneGrid({
-  onSelectScene,
-  onBlankSceneClick
-}: SceneGridProps) {
+export function SceneGrid({ onBlankSceneClick }: SceneGridProps) {
   const { isAuthenticated } = useAuth();
   return (
     <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={6}>
       {SAMPLE_SCENES.map((scene) => (
-        <SceneCard key={scene.id} scene={scene} onSelect={onSelectScene} />
+        <SceneCard key={scene.id} scene={scene} />
       ))}
       {isAuthenticated && <BlankCard onSelect={onBlankSceneClick} />}
     </SimpleGrid>

--- a/app/config/sample-scenes.ts
+++ b/app/config/sample-scenes.ts
@@ -40,19 +40,21 @@ export const SAMPLE_SCENES: SampleScene[] = [
   }
 ];
 
+const DEFAULT_BLANK_SCENE: SampleScene = {
+  id: BLANK_SCENE_ID,
+  name: 'Custom Analysis',
+  description: 'Configure your own data source',
+  collectionId: '',
+  temporalRange: ['', ''] as [string, string],
+  suggestedAlgorithm: '',
+  defaultBands: [],
+  boundingBox: [0, -90, 180, 90], // west, south, east, north
+  cloudCover: 20 // Max cloud cover percentage
+};
+
 export function getSceneById(id: string): SampleScene | undefined {
   if (id === BLANK_SCENE_ID) {
-    return {
-      id: BLANK_SCENE_ID,
-      name: 'Custom Analysis',
-      description: 'Configure your own data source',
-      collectionId: '',
-      temporalRange: ['', ''] as [string, string],
-      suggestedAlgorithm: '',
-      defaultBands: [],
-      boundingBox: [0, -90, 180, 90], // west, south, east, north
-      cloudCover: 20 // Max cloud cover percentage
-    };
+    return DEFAULT_BLANK_SCENE;
   }
   return SAMPLE_SCENES.find((scene) => scene.id === id);
 }

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -3,12 +3,14 @@ import { createRoot } from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
 import { AuthProvider, AuthProviderProps } from 'react-oidc-context';
 import { StacApiProvider } from '@developmentseed/stac-react';
+import { BrowserRouter } from 'react-router';
 
 import { PyodideProvider } from '$contexts/pyodide-context';
 
 import system from './styles/theme';
 
 import App from './app';
+import ErrorBoundary from '$pages/uhoh/boundary';
 
 const publicUrl = import.meta.env.VITE_BASE_URL || '';
 const authAuthority = import.meta.env.VITE_AUTH_AUTHORITY || '';
@@ -44,15 +46,19 @@ function Root() {
   }, []);
 
   return (
-    <AuthProvider {...oidcConfig}>
-      <ChakraProvider value={system}>
-        <StacApiProvider apiUrl='https://api.explorer.eopf.copernicus.eu/openeo'>
-          <PyodideProvider>
-            <App />
-          </PyodideProvider>
-        </StacApiProvider>
-      </ChakraProvider>
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider {...oidcConfig}>
+        <ChakraProvider value={system}>
+          <ErrorBoundary>
+            <StacApiProvider apiUrl='https://api.explorer.eopf.copernicus.eu/openeo'>
+              <PyodideProvider>
+                <App />
+              </PyodideProvider>
+            </StacApiProvider>
+          </ErrorBoundary>
+        </ChakraProvider>
+      </AuthProvider>
+    </BrowserRouter>
   );
 }
 

--- a/app/pages/landing-page.tsx
+++ b/app/pages/landing-page.tsx
@@ -1,25 +1,19 @@
 import { useState } from 'react';
 import { Box, Flex, Heading, Text } from '@chakra-ui/react';
 import { useAuth } from 'react-oidc-context';
+import { useNavigate } from 'react-router';
 import { SceneGrid } from '$components/landing/scene-grid';
 import { DataConfigDialog } from '$components/setup/data-config-dialog';
 import { APP_TITLE } from '$config/constants';
+import { useSceneValues } from '../stores/scene/selectors';
+import { BLANK_SCENE_ID, getSceneById } from '$config/sample-scenes';
 
-interface LandingPageProps {
-  onSelectScene: (sceneId: string) => void;
-  onStartFromScratch: (config: {
-    collectionId: string;
-    temporalRange: [string, string];
-    cloudCover: number;
-  }) => void;
-}
-
-export function LandingPage({
-  onSelectScene,
-  onStartFromScratch
-}: LandingPageProps) {
+export function LandingPage() {
   const { isAuthenticated, isLoading } = useAuth();
   const [isConfigOpen, setIsConfigOpen] = useState(false);
+
+  const [, setSceneValues] = useSceneValues();
+  const navigate = useNavigate();
 
   const handleBlankSceneClick = () => {
     setIsConfigOpen(true);
@@ -31,7 +25,16 @@ export function LandingPage({
     cloudCover: number;
   }) => {
     setIsConfigOpen(false);
-    onStartFromScratch(config);
+
+    const blankScene = getSceneById(BLANK_SCENE_ID)!;
+
+    setSceneValues({
+      collectionId: config.collectionId,
+      temporalRange: config.temporalRange,
+      cloudCover: config.cloudCover,
+      selectedBands: blankScene.defaultBands
+    });
+    navigate(`/editor/${BLANK_SCENE_ID}`);
   };
 
   const handleConfigCancel = () => {
@@ -50,10 +53,7 @@ export function LandingPage({
           </Text>
         </Flex>
 
-        <SceneGrid
-          onSelectScene={onSelectScene}
-          onBlankSceneClick={handleBlankSceneClick}
-        />
+        <SceneGrid onBlankSceneClick={handleBlankSceneClick} />
 
         {!isAuthenticated && !isLoading && (
           <Text fontSize='md' color='orange.600' fontWeight='medium'>

--- a/app/pages/landing-page.tsx
+++ b/app/pages/landing-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Flex, Heading, Text } from '@chakra-ui/react';
 import { useAuth } from 'react-oidc-context';
 import { useNavigate } from 'react-router';
@@ -14,6 +14,11 @@ export function LandingPage() {
 
   const [, setSceneValues] = useSceneValues();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    // Reset when the user is back to the landing page.
+    setSceneValues();
+  }, []);
 
   const handleBlankSceneClick = () => {
     setIsConfigOpen(true);

--- a/app/pages/uhoh/404.tsx
+++ b/app/pages/uhoh/404.tsx
@@ -1,0 +1,14 @@
+import { Heading, Text, VStack } from '@chakra-ui/react';
+
+export default function UhOh404() {
+  return (
+    <VStack as='main' h='100%' gap={0} p={20}>
+      <title>OpenEO Studio - Page not found</title>
+
+      <Heading size='7xl'>404</Heading>
+      <Text fontSize='2xl' mt={4}>
+        UhOh! The page you are looking for is missing
+      </Text>
+    </VStack>
+  );
+}

--- a/app/pages/uhoh/404.tsx
+++ b/app/pages/uhoh/404.tsx
@@ -3,7 +3,7 @@ import { Heading, Text, VStack } from '@chakra-ui/react';
 export default function UhOh404() {
   return (
     <VStack as='main' h='100%' gap={0} p={20}>
-      <title>OpenEO Studio - Page not found</title>
+      <title>{import.meta.env.VITE_APP_TITLE} - Page not found</title>
 
       <Heading size='7xl'>404</Heading>
       <Text fontSize='2xl' mt={4}>

--- a/app/pages/uhoh/500.tsx
+++ b/app/pages/uhoh/500.tsx
@@ -4,7 +4,7 @@ import { Heading, Text, VStack } from '@chakra-ui/react';
 export default function UhOh500() {
   return (
     <VStack as='main' h='100%' gap={0} p={20}>
-      <title>OpenEO Studio - Critical Error</title>
+      <title>{import.meta.env.VITE_APP_TITLE} - Critical Error</title>
 
       <Heading size='7xl'>500</Heading>
       <Text fontSize='2xl' mt={4}>

--- a/app/pages/uhoh/500.tsx
+++ b/app/pages/uhoh/500.tsx
@@ -1,0 +1,22 @@
+import SmartLink from '$components/common/smart-link';
+import { Heading, Text, VStack } from '@chakra-ui/react';
+
+export default function UhOh500() {
+  return (
+    <VStack as='main' h='100%' gap={0} p={20}>
+      <title>OpenEO Studio - Critical Error</title>
+
+      <Heading size='7xl'>500</Heading>
+      <Text fontSize='2xl' mt={4}>
+        Oh Snap! Something went wrong on our end.
+      </Text>
+      <Text fontSize='lg' mt={2}>
+        Try to reload the page or go back to the{' '}
+        <SmartLink to='/' variant='underline' colorPalette='primary'>
+          homepage
+        </SmartLink>
+        ?
+      </Text>
+    </VStack>
+  );
+}

--- a/app/pages/uhoh/boundary.tsx
+++ b/app/pages/uhoh/boundary.tsx
@@ -1,0 +1,73 @@
+import { Component, ReactNode } from 'react';
+import { Flex } from '@chakra-ui/react';
+import { useLocation } from 'react-router';
+
+import { AppHeader } from '$components/layout/app-header';
+import { useEffectAfterMount } from '$utils/use-effect-after-mount';
+import { NotFound } from './error';
+import UhOh404 from './404';
+import UhOh500 from './500';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  resetError() {
+    this.setState({ hasError: false, error: undefined });
+  }
+
+  // componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+  //   console.error('ErrorBoundary caught an error', error, errorInfo);
+  // }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ErrorWrapper resetError={this.resetError.bind(this)}>
+          {this.state.error instanceof NotFound ? <UhOh404 /> : <UhOh500 />}
+        </ErrorWrapper>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;
+
+interface ErrorWrapperProps {
+  children: ReactNode;
+  resetError: () => void;
+}
+
+function ErrorWrapper(props: ErrorWrapperProps) {
+  const { children, resetError } = props;
+
+  const loc = useLocation().pathname;
+
+  useEffectAfterMount(() => {
+    resetError();
+  }, [loc]);
+
+  return (
+    <Flex minH='100vh' direction='column'>
+      <AppHeader />
+      {children}
+    </Flex>
+  );
+}

--- a/app/pages/uhoh/error.ts
+++ b/app/pages/uhoh/error.ts
@@ -1,0 +1,9 @@
+export class NotFound extends Error {
+  details: any = null;
+
+  constructor(message: string, details?: any) {
+    super(message);
+    this.name = 'NotFound';
+    this.details = details;
+  }
+}

--- a/app/stores/scene/index.ts
+++ b/app/stores/scene/index.ts
@@ -1,0 +1,43 @@
+import { ServiceInfo } from '$types';
+import { createStore } from '@xstate/store';
+
+const initialState = {
+  services: [] as ServiceInfo[],
+  collectionId: '',
+  temporalRange: ['', ''] as [string, string],
+  cloudCover: 100,
+  selectedBands: [] as string[]
+};
+
+export const sceneStore = createStore({
+  // Initial context
+  context: initialState,
+  // Transitions
+  on: {
+    reset: (_, event: { newState?: Partial<typeof initialState> }) =>
+      event.newState ? { ...initialState, ...event.newState } : initialState,
+    setServices: (context, event: { services: ServiceInfo[] }) => ({
+      ...context,
+      services: event.services
+    }),
+    setCollectionId: (context, event: { collectionId: string }) => ({
+      ...context,
+      collectionId: event.collectionId
+    }),
+    setTemporalRange: (
+      context,
+      event: { temporalRange: [string, string] }
+    ) => ({
+      ...context,
+      temporalRange: event.temporalRange
+    }),
+    setCloudCover: (context, event: { cloudCover: number }) => ({
+      ...context,
+      cloudCover: event.cloudCover
+    }),
+    setSelectedBands: (context, event: { selectedBands: string[] }) => ({
+      ...context,
+      selectedBands: event.selectedBands
+    })
+  }
+});

--- a/app/stores/scene/selectors.ts
+++ b/app/stores/scene/selectors.ts
@@ -1,0 +1,53 @@
+import { useSelector } from '@xstate/store/react';
+import { sceneStore } from '.';
+import { ServiceInfo } from '$types';
+import { SnapshotFromStore } from '@xstate/store';
+
+type SceneResetValue = Partial<SnapshotFromStore<typeof sceneStore>['context']>;
+export const useSceneValues = () =>
+  [
+    useSelector(sceneStore, (state) => state.context),
+    (value?: SceneResetValue) => {
+      sceneStore.trigger.reset({ newState: value });
+    }
+  ] as const;
+
+export const useServices = () =>
+  [
+    useSelector(sceneStore, (state) => state.context.services),
+    (value: ServiceInfo[]) => {
+      sceneStore.trigger.setServices({ services: value });
+    }
+  ] as const;
+
+export const useCollectionId = () =>
+  [
+    useSelector(sceneStore, (state) => state.context.collectionId),
+    (value: string) => {
+      sceneStore.trigger.setCollectionId({ collectionId: value });
+    }
+  ] as const;
+
+export const useTemporalRange = () =>
+  [
+    useSelector(sceneStore, (state) => state.context.temporalRange),
+    (value: [string, string]) => {
+      sceneStore.trigger.setTemporalRange({ temporalRange: value });
+    }
+  ] as const;
+
+export const useCloudCover = () =>
+  [
+    useSelector(sceneStore, (state) => state.context.cloudCover),
+    (value: number) => {
+      sceneStore.trigger.setCloudCover({ cloudCover: value });
+    }
+  ] as const;
+
+export const useSelectedBands = () =>
+  [
+    useSelector(sceneStore, (state) => state.context.selectedBands),
+    (value: string[]) => {
+      sceneStore.trigger.setSelectedBands({ selectedBands: value });
+    }
+  ] as const;

--- a/app/utils/use-effect-after-mount.ts
+++ b/app/utils/use-effect-after-mount.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+
+export function useEffectAfterMount(
+  effect: () => void | (() => void),
+  deps: any[]
+) {
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    return effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@uiw/codemirror-theme-github": "^4.25.4",
+    "@xstate/store": "^3.14.1",
     "codemirror": "^6.0.2",
     "maplibre-gl": "^5.12.0",
     "polished": "^4.3.1",
@@ -80,6 +81,7 @@
     "react-map-gl": "^8.1.0",
     "react-markdown": "^10.1.0",
     "react-oidc-context": "^3.3.0",
+    "react-router": "^7.12.0",
     "remark-gfm": "^4.0.1",
     "stac-ts": "^1.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@uiw/codemirror-theme-github':
         specifier: ^4.25.4
         version: 4.25.4(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.8)
+      '@xstate/store':
+        specifier: ^3.14.1
+        version: 3.14.1(react@19.2.0)
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
@@ -77,6 +80,9 @@ importers:
       react-oidc-context:
         specifier: ^3.3.0
         version: 3.3.0(oidc-client-ts@3.4.0)(react@19.2.0)
+      react-router:
+        specifier: ^7.12.0
+        version: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1370,6 +1376,17 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@xstate/store@3.14.1':
+    resolution: {integrity: sha512-LNl4XspU9Yp1bV9Igvbzz0pwDtm9ya9bSqbT9WB6nvLaP6Kie9d/FTlq3gLlKcbelaJDLTLBf5kKPfbiwkbAjA==}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      solid-js: ^1.7.6
+    peerDependenciesMeta:
+      react:
+        optional: true
+      solid-js:
+        optional: true
+
   '@zag-js/accordion@1.31.1':
     resolution: {integrity: sha512-3sGi4EZpGBz/O1IVkk9dzzWzP5vVVOj4Li6C+jHOnrgaWPouA/mBTP5L9HEL8qtFsECFZwpNo486eqiCmeHoGw==}
 
@@ -1864,6 +1881,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -3335,6 +3356,16 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.12.0:
+    resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
@@ -3439,6 +3470,9 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5384,6 +5418,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@xstate/store@3.14.1(react@19.2.0)':
+    optionalDependencies:
+      react: 19.2.0
+
   '@zag-js/accordion@1.31.1':
     dependencies:
       '@zag-js/anatomy': 1.31.1
@@ -6228,6 +6266,8 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -8242,6 +8282,14 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router@7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.0
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.0(react@19.2.0)
+
   react@19.2.0: {}
 
   redent@3.0.0:
@@ -8397,6 +8445,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
This PR implementing routing in the app for the main page and the editor. Components were updated to use links for navigation instead of callback functions.

A error boundary was added to catch critical errors and not found errors. Pages were added for the different error types (500 & 404).

A store was introduced to manage the scene state (through xstate). This is mainly used to configure the blank scene and avoid passing the configuration through route components. In the future this could be extended to manage more of the editor state.

Fix #17