### PR TITLE
Add React Router for Scene Permalinks

### DIFF
--- a/app/components/auth/user-info.tsx
+++ b/app/components/auth/user-info.tsx
@@ -1,6 +1,7 @@
 import { Button, Image } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { useAuth } from 'react-oidc-context';
+import { useLocation } from 'react-router';
 
 async function hash(string: string) {
   const utf8 = new TextEncoder().encode(string);
@@ -15,6 +16,7 @@ async function hash(string: string) {
 export function UserInfo() {
   const { isLoading, isAuthenticated, user, signinRedirect, removeUser } =
     useAuth();
+  const location = useLocation();
 
   const profile = user?.profile;
 
@@ -32,7 +34,10 @@ export function UserInfo() {
         onClick={(e) => {
           e.preventDefault();
           if (!isLoading) {
-            signinRedirect();
+            // Pass current location through OIDC state parameter
+            signinRedirect({
+              state: { returnTo: location.pathname }
+            });
           }
         }}
         layerStyle='handDrawn'

--- a/app/components/landing/scene-card.tsx
+++ b/app/components/landing/scene-card.tsx
@@ -9,13 +9,13 @@ import {
 } from '@chakra-ui/react';
 import { useCollection } from '@developmentseed/stac-react';
 import { SampleScene } from '$types';
+import SmartLink from '$utils/smart-link';
 
 interface SceneCardProps {
   scene: SampleScene;
-  onSelect: (sceneId: string) => void;
 }
 
-export function SceneCard({ scene, onSelect }: SceneCardProps) {
+export function SceneCard({ scene }: SceneCardProps) {
   const { collection, isLoading } = useCollection(scene.collectionId);
 
   // Extract thumbnail from STAC item assets
@@ -23,62 +23,64 @@ export function SceneCard({ scene, onSelect }: SceneCardProps) {
 
   return (
     <Card.Root
-      onClick={() => onSelect(scene.id)}
       cursor='pointer'
+      asChild
       transition='all 0.2s'
       _hover={{
         transform: 'translateY(-4px)',
         shadow: 'lg'
       }}
     >
-      <Card.Body gap={4}>
-        {/* Thumbnail */}
-        {isLoading ? (
-          <Box
-            height='200px'
-            width='100%'
-            bg='gray.100'
-            borderRadius='md'
-            display='flex'
-            alignItems='center'
-            justifyContent='center'
-          >
-            <Spinner size='lg' />
-          </Box>
-        ) : thumbnail ? (
-          <Image
-            src={thumbnail}
-            alt={scene.name}
-            height='200px'
-            width='100%'
-            objectFit='cover'
-            borderRadius='md'
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-            }}
-          />
-        ) : (
-          <Box
-            height='200px'
-            width='100%'
-            bg='gray.200'
-            borderRadius='md'
-            display='flex'
-            alignItems='center'
-            justifyContent='center'
-          >
-            <Text color='gray.500'>No Preview</Text>
-          </Box>
-        )}
+      <SmartLink to={`/editor/${scene.id}`} unstyled>
+        <Card.Body gap={4}>
+          {/* Thumbnail */}
+          {isLoading ? (
+            <Box
+              height='200px'
+              width='100%'
+              bg='gray.100'
+              borderRadius='md'
+              display='flex'
+              alignItems='center'
+              justifyContent='center'
+            >
+              <Spinner size='lg' />
+            </Box>
+          ) : thumbnail ? (
+            <Image
+              src={thumbnail}
+              alt={scene.name}
+              height='200px'
+              width='100%'
+              objectFit='cover'
+              borderRadius='md'
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
+            />
+          ) : (
+            <Box
+              height='200px'
+              width='100%'
+              bg='gray.200'
+              borderRadius='md'
+              display='flex'
+              alignItems='center'
+              justifyContent='center'
+            >
+              <Text color='gray.500'>No Preview</Text>
+            </Box>
+          )}
 
-        {/* Scene info */}
-        <Flex flexDirection='column' gap={2}>
-          <Heading size='md'>{scene.name}</Heading>
-          <Text fontSize='sm' color='gray.600'>
-            {scene.description}
-          </Text>
-        </Flex>
-      </Card.Body>
+          {/* Scene info */}
+          <Flex flexDirection='column' gap={2}>
+            <Heading size='md'>{scene.name}</Heading>
+            <Text fontSize='sm' color='gray.600'>
+              {scene.description}
+            </Text>
+          </Flex>
+        </Card.Body>
+      </SmartLink>
     </Card.Root>
   );
 }

--- a/app/components/landing/scene-grid.tsx
+++ b/app/components/landing/scene-grid.tsx
@@ -6,19 +6,15 @@ import { SceneCard } from './scene-card';
 import { BlankCard } from './blank-card';
 
 interface SceneGridProps {
-  onSelectScene: (sceneId: string) => void;
   onBlankSceneClick: () => void;
 }
 
-export function SceneGrid({
-  onSelectScene,
-  onBlankSceneClick
-}: SceneGridProps) {
+export function SceneGrid({ onBlankSceneClick }: SceneGridProps) {
   const { isAuthenticated } = useAuth();
   return (
     <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={6}>
       {SAMPLE_SCENES.map((scene) => (
-        <SceneCard key={scene.id} scene={scene} onSelect={onSelectScene} />
+        <SceneCard key={scene.id} scene={scene} />
       ))}
       {isAuthenticated && <BlankCard onSelect={onBlankSceneClick} />}
     </SimpleGrid>

--- a/app/pages/editor-page.tsx
+++ b/app/pages/editor-page.tsx
@@ -1,40 +1,72 @@
 import { useState, useMemo } from 'react';
 import { Flex, IconButton, Button, Dialog, Splitter } from '@chakra-ui/react';
 import { useCollection } from '@developmentseed/stac-react';
+import { useParams, useLocation, useNavigate } from 'react-router';
+import { useAuth } from 'react-oidc-context';
+import { StacCollection } from 'stac-ts';
 
 import { EditorPanel } from '$components/layout/editor-panel';
 import { MapPanel } from '$components/layout/map-panel';
 import { DataConfigDialog } from '$components/setup/data-config-dialog';
 import { extractBandsFromStac } from '$utils/stac-band-parser';
-import type { SampleScene, ServiceInfo } from '$types';
-import { StacCollection } from 'stac-ts';
+import type { ServiceInfo } from '$types';
+import { getSceneById, BLANK_SCENE_ID } from '$config/sample-scenes';
+import SmartLink from '$utils/smart-link';
 
-interface EditorPageProps {
-  scene: SampleScene;
-  onBack: () => void;
-}
+export function EditorPage() {
+  const { sceneId } = useParams<{ sceneId: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { isLoading } = useAuth();
 
-export function EditorPage({ scene, onBack }: EditorPageProps) {
+  const scene = getSceneById(sceneId!);
+
+  // For blank scenes, location.state overrides scene defaults
+  const blankSceneConfig = location.state as {
+    collectionId: string;
+    temporalRange: [string, string];
+    cloudCover: number;
+  } | null;
+
+  const isBlankScene = scene?.id === BLANK_SCENE_ID && blankSceneConfig;
+
   const [services, setServices] = useState<ServiceInfo[]>([]);
   const [isInspectOpen, setIsInspectOpen] = useState(false);
   const [isConfigOpen, setIsConfigOpen] = useState(false);
 
   // Data configuration state
-  const [collectionId, setCollectionId] = useState(scene.collectionId);
-  const [temporalRange, setTemporalRange] = useState<[string, string]>(
-    scene.temporalRange
+  const [collectionId, setCollectionId] = useState(
+    isBlankScene ? blankSceneConfig.collectionId : scene?.collectionId || ''
   );
-  const [cloudCover, setCloudCover] = useState(scene.cloudCover || 100);
+  const [temporalRange, setTemporalRange] = useState<[string, string]>(
+    isBlankScene
+      ? blankSceneConfig.temporalRange
+      : scene?.temporalRange || ['', '']
+  );
+  const [cloudCover, setCloudCover] = useState(
+    isBlankScene ? blankSceneConfig.cloudCover : scene?.cloudCover || 100
+  );
+  const [selectedBands, setSelectedBands] = useState<string[]>(
+    scene?.defaultBands || []
+  );
 
   const { collection: collectionRaw } = useCollection(collectionId);
   const collection = collectionRaw as unknown as StacCollection | null;
 
   // Extract band metadata from STAC item
   const bands = useMemo(() => extractBandsFromStac(collection), [collection]);
-  // Manage selected bands for data[] array
-  const [selectedBands, setSelectedBands] = useState<string[]>(
-    scene.defaultBands
-  );
+  const mapBounds = useMemo(() => scene?.boundingBox, [scene]);
+
+  // Early return
+  if (isLoading) {
+    return null; // Still loading auth state
+  }
+
+  if (!scene) {
+    // Scene not found - navigate back
+    navigate('/', { replace: true });
+    return null;
+  }
 
   // Handle layer visibility toggle
   const handleToggleLayer = (serviceId: string) => {
@@ -75,10 +107,6 @@ export function EditorPage({ scene, onBack }: EditorPageProps) {
     setIsConfigOpen(e.open);
   };
 
-  const mapBounds = useMemo(() => {
-    return scene.boundingBox;
-  }, []);
-
   return (
     <Flex flexDirection='column' flex={1} minHeight={0}>
       {/* Sub-header with back button and scene info */}
@@ -93,20 +121,22 @@ export function EditorPage({ scene, onBack }: EditorPageProps) {
       >
         <IconButton
           aria-label='Back to scenes'
-          onClick={onBack}
           size='sm'
           variant='ghost'
+          asChild
         >
-          <svg
-            version='1.1'
-            xmlns='http://www.w3.org/2000/svg'
-            width='16'
-            height='16'
-            viewBox='0 0 16 16'
-          >
-            <rect width='16' height='16' id='icon-bound' fill='none' />
-            <polygon points='8.414,13.586 3.828,9 16,9 16,7 3.828,7 8.414,2.414 7,1 0,8 7,15' />
-          </svg>
+          <SmartLink to='/'>
+            <svg
+              version='1.1'
+              xmlns='http://www.w3.org/2000/svg'
+              width='16'
+              height='16'
+              viewBox='0 0 16 16'
+            >
+              <rect width='16' height='16' id='icon-bound' fill='none' />
+              <polygon points='8.414,13.586 3.828,9 16,9 16,7 3.828,7 8.414,2.414 7,1 0,8 7,15' />
+            </svg>
+          </SmartLink>
         </IconButton>
         <Flex flexDirection='column' flex={1}>
           <Flex fontSize='md' fontWeight='semibold'>

--- a/app/pages/landing-page.tsx
+++ b/app/pages/landing-page.tsx
@@ -1,25 +1,16 @@
 import { useState } from 'react';
 import { Box, Flex, Heading, Text } from '@chakra-ui/react';
 import { useAuth } from 'react-oidc-context';
+import { useNavigate } from 'react-router';
 import { SceneGrid } from '$components/landing/scene-grid';
 import { DataConfigDialog } from '$components/setup/data-config-dialog';
 import { APP_TITLE } from '$config/constants';
+import { BLANK_SCENE_ID } from '$config/sample-scenes';
 
-interface LandingPageProps {
-  onSelectScene: (sceneId: string) => void;
-  onStartFromScratch: (config: {
-    collectionId: string;
-    temporalRange: [string, string];
-    cloudCover: number;
-  }) => void;
-}
-
-export function LandingPage({
-  onSelectScene,
-  onStartFromScratch
-}: LandingPageProps) {
+export function LandingPage() {
   const { isAuthenticated, isLoading } = useAuth();
   const [isConfigOpen, setIsConfigOpen] = useState(false);
+  const navigate = useNavigate();
 
   const handleBlankSceneClick = () => {
     setIsConfigOpen(true);
@@ -31,7 +22,8 @@ export function LandingPage({
     cloudCover: number;
   }) => {
     setIsConfigOpen(false);
-    onStartFromScratch(config);
+    // Navigate to editor with blank scene config in location state
+    navigate(`/editor/${BLANK_SCENE_ID}`, { state: config });
   };
 
   const handleConfigCancel = () => {
@@ -50,10 +42,7 @@ export function LandingPage({
           </Text>
         </Flex>
 
-        <SceneGrid
-          onSelectScene={onSelectScene}
-          onBlankSceneClick={handleBlankSceneClick}
-        />
+        <SceneGrid onBlankSceneClick={handleBlankSceneClick} />
 
         {!isAuthenticated && !isLoading && (
           <Text fontSize='md' color='orange.600' fontWeight='medium'>

--- a/app/utils/smart-link.tsx
+++ b/app/utils/smart-link.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react';
+import { Link as ChLink, LinkProps } from '@chakra-ui/react';
+import { Link, To } from 'react-router';
+
+export interface SmartLinkProps extends LinkProps {
+  to: To;
+}
+
+export default forwardRef<HTMLAnchorElement, SmartLinkProps>(
+  function SmartLink(props, ref) {
+    const { to, children, ...rest } = props;
+
+    const isExternal =
+      typeof to === 'string' &&
+      (to.match(/^(https?:)?\/\//) || to.match(/^(mailto|tel):/));
+
+    return isExternal ? (
+      <ChLink ref={ref} href={to} {...rest}>
+        {children}
+      </ChLink>
+    ) : (
+      <ChLink ref={ref} asChild {...rest}>
+        <Link to={to}>{children}</Link>
+      </ChLink>
+    );
+  }
+);

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-map-gl": "^8.1.0",
     "react-markdown": "^10.1.0",
     "react-oidc-context": "^3.3.0",
+    "react-router": "^7.12.0",
     "remark-gfm": "^4.0.1",
     "stac-ts": "^1.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react-oidc-context:
         specifier: ^3.3.0
         version: 3.3.0(oidc-client-ts@3.4.0)(react@19.2.0)
+      react-router:
+        specifier: ^7.12.0
+        version: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1865,6 +1868,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -3335,6 +3342,16 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.12.0:
+    resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
@@ -3439,6 +3456,9 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6229,6 +6249,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -8242,6 +8264,14 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router@7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.0
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.0(react@19.2.0)
+
   react@19.2.0: {}
 
   redent@3.0.0:
@@ -8397,6 +8427,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
Implements client-side routing to enable shareable scene URLs (e.g., `/editor/:sceneId`), addressing the core requirement from #17 while taking a simpler approach compared to #30 .

What this adds:

- **Permalinks**: Users can share direct links to specific scenes  
- **Post-login redirect**: Login returns user to the same scene they were viewing  
- **Browser navigation**: Back/forward buttons work correctly  
- **Blank scene flow**: Custom configuration passed via `location.state`

## Implementation Details

### Routing Structure

- `/` - Landing page with scene grid
- `/editor/:sceneId` - Editor with scene parameter

### Post-Login Redirect Flow

1. User clicks login while viewing `/editor/:sceneId`
2. `signinRedirect({ state: { returnTo: location.pathname } })`
3. OAuth flow completes → `onSigninCallback` stores path in sessionStorage
4. App component reads sessionStorage → `navigate(postAuthPath)`
5. User returns to original scene

### Blank Scene Configuration

Uses React Router's built-in `location.state`:

```tsx
// Landing page
navigate(`/editor/blank-scene`, { state: config });

// Editor page
const blankSceneConfig = location.state;
```

### SmartLink Component

Unified link component that:

- Uses React Router `<Link>` for internal routes
- Uses Chakra `<Link>` for external URLs
- Leverages Chakra's `asChild` for cleaner DOM

## Differences from PR #30

| Feature | PR #30 | This PR |
|---------|--------|---------|
| **Routing** | ✅ React Router 7 | ✅ React Router 7 |
| **State Management** | `@xstate/store` | React Router `location.state` |
| **Error Boundaries** | Custom 404/500 pages | ❌ (would be nice as a separate PR) |
| **Dependencies Added** | 2 (`react-router`, `@xstate/store`) | 1 (`react-router`) |
| **Post-login redirect** | ❌ Not implemented | ✅ OIDC state + sessionStorage |

## Rationale for Simpler Approach

**Why not `@xstate/store`?**

- React Router's `location.state` already solves the blank scene config problem
- No need for global state when data is scoped to a single navigation
- Reduces bundle size and complexity
- Standard React Router pattern

**Why no error boundaries yet?**

- Can be added incrementally if needed
- Not required for basic permalink functionality
- Keeps this PR focused on core routing

## Manual Testing Done

- ✅ Scene cards navigate correctly
- ✅ Blank scene configuration passed via location.state
- ✅ Login/logout flow preserves current scene
- ✅ Back/forward buttons work
- ✅ Direct URL access works (e.g., paste `/editor/:sceneId` in browser)
- ✅ Auth loading spinner prevents landing content flash

_Note: Yes, we need automated tests!_

@danielfdsilva as discussed on slack, this would be my cherry-pick. What do you think?