### PR TITLE
Update cloud cover argument and enable slider control

### DIFF
--- a/app/algorithms/base/loader.py
+++ b/app/algorithms/base/loader.py
@@ -47,7 +47,7 @@ graph = PGNode(
             "process_graph": {
                 "cc": {
                     "process_id": "lt",
-                    "arguments": {"x": {"from_parameter": "value"}, "y": 20},
+                    "arguments": {"x": {"from_parameter": "value"}, "y": {"from_parameter": "cloud_cover_max"}},
                     "result": True,
                 }
             }

--- a/app/components/setup/data-config-form.tsx
+++ b/app/components/setup/data-config-form.tsx
@@ -201,7 +201,6 @@ export function DataConfigForm({
               min={0}
               max={100}
               step={5}
-              disabled={true} // TODO: disabled while backend support is added
             >
               <Slider.Control>
                 <Slider.Track>


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Enable the cloud cover slider on "Start from scratch" functionality that was previously disabled due to missing backend support

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Removed `disabled={true}` attribute from the cloud cover slider in DataConfigForm component
- Fixed the OpenEO process graph in loader.py to use the dynamic `cloud_cover_max` parameter instead of hardcoded value `20`
- Verified the complete data flow from UI slider → application state → backend execution → OpenEO filtering

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Click "Start from scratch" on the landing page
- Adjust the "Maximum Cloud Cover" slider (should now be interactive)
- Set different cloud cover values (e.g., 10%, 50%, 80%) and confirm the slider responds
- Apply the configuration and verify that satellite data filtering respects the selected cloud cover threshold

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Closes #37