### PR TITLE
fix: Enable Apply button after config changes 

### DIFF
--- a/app/components/editor/editor-toolbar.tsx
+++ b/app/components/editor/editor-toolbar.tsx
@@ -7,6 +7,7 @@ interface EditorToolbarProps {
   isReady: boolean;
   showAutoExecHint?: boolean;
   hasCodeChanged: boolean;
+  hasConfigChanged: boolean;
 }
 
 export function EditorToolbar({
@@ -14,7 +15,8 @@ export function EditorToolbar({
   isExecuting,
   isReady,
   showAutoExecHint,
-  hasCodeChanged
+  hasCodeChanged,
+  hasConfigChanged
 }: EditorToolbarProps) {
   const { isAuthenticated } = useAuth();
 
@@ -36,7 +38,10 @@ export function EditorToolbar({
           size='sm'
           variant='outline'
           disabled={
-            !isReady || isExecuting || !isAuthenticated || !hasCodeChanged
+            !isReady ||
+            isExecuting ||
+            !isAuthenticated ||
+            !(hasCodeChanged || hasConfigChanged)
           }
           onClick={executeCode}
           loading={isExecuting}

--- a/app/components/layout/editor-header.tsx
+++ b/app/components/layout/editor-header.tsx
@@ -11,9 +11,9 @@ interface EditorHeaderProps {
 function EditorHeaderComponent({ sceneName }: EditorHeaderProps) {
   const { collectionId, temporalRange, cloudCover } = useEditorStore(
     useShallow((state) => ({
-      collectionId: state.collectionId,
-      temporalRange: state.temporalRange,
-      cloudCover: state.cloudCover
+      collectionId: state.selectedConfig.collectionId,
+      temporalRange: state.selectedConfig.temporalRange,
+      cloudCover: state.selectedConfig.cloudCover
     }))
   );
   return (

--- a/app/components/layout/editor-panel.tsx
+++ b/app/components/layout/editor-panel.tsx
@@ -55,15 +55,23 @@ function EditorPanelContent({
   defaultTab?: 'configuration' | 'code';
   autoExecuteOnReady?: boolean;
 }) {
-  const config = useEditorStore(
-    useShallow((state) => ({
-      collectionId: state.collectionId,
-      selectedBands: state.selectedBands,
-      temporalRange: state.temporalRange,
-      boundingBox: state.boundingBox,
-      cloudCover: state.cloudCover
-    }))
+  const selectedConfig = useEditorStore(
+    useShallow((state) => state.selectedConfig)
   );
+
+  const previousConfig = useEditorStore(
+    useShallow((state) => state.previousConfig)
+  );
+
+  const hasConfigChanged =
+    selectedConfig.collectionId !== previousConfig.collectionId ||
+    selectedConfig.cloudCover !== previousConfig.cloudCover ||
+    JSON.stringify(selectedConfig.temporalRange) !==
+      JSON.stringify(previousConfig.temporalRange) ||
+    JSON.stringify(selectedConfig.selectedBands) !==
+      JSON.stringify(previousConfig.selectedBands) ||
+    JSON.stringify(selectedConfig.boundingBox) !==
+      JSON.stringify(previousConfig.boundingBox);
 
   const { setServices, setSelectedBands, setTemporalRange, setCloudCover } =
     useEditorStore();
@@ -81,7 +89,7 @@ function EditorPanelContent({
     isReady: isExecutionReady,
     errorMessage,
     hasCodeChanged
-  } = useCodeExecution(setServices, editor, config);
+  } = useCodeExecution(setServices, editor, selectedConfig);
 
   const hasAutoExecutedRef = useRef(false);
   useEffect(() => {
@@ -139,7 +147,7 @@ function EditorPanelContent({
                           Available Variables
                         </Popover.Title>
                         <AvailableVariables
-                          selectedBands={config.selectedBands || []}
+                          selectedBands={selectedConfig.selectedBands || []}
                         />
                       </Popover.Body>
                     </Popover.Content>
@@ -152,12 +160,12 @@ function EditorPanelContent({
 
         <Tabs.Content value='configuration' flex={1} overflow='auto' p={4}>
           <ConfigurationTab
-            collectionId={config.collectionId}
-            temporalRange={config.temporalRange}
-            cloudCover={config.cloudCover || 100}
-            selectedBands={config.selectedBands || []}
+            collectionId={selectedConfig.collectionId}
+            temporalRange={selectedConfig.temporalRange}
+            cloudCover={selectedConfig.cloudCover || 100}
+            selectedBands={selectedConfig.selectedBands || []}
             availableBands={availableBands}
-            boundingBox={config.boundingBox}
+            boundingBox={selectedConfig.boundingBox}
             onTemporalRangeChange={setTemporalRange}
             onCloudCoverChange={setCloudCover}
             onSelectedBandsChange={setSelectedBands}
@@ -192,6 +200,7 @@ function EditorPanelContent({
         executeCode={executeCode}
         showAutoExecHint={showAutoExecHint}
         hasCodeChanged={hasCodeChanged}
+        hasConfigChanged={hasConfigChanged}
       />
     </Flex>
   );

--- a/app/components/layout/map-panel.tsx
+++ b/app/components/layout/map-panel.tsx
@@ -11,7 +11,7 @@ import { useEditorStore } from '$stores/editor-store';
 function MapPanelComponent() {
   const { bounds, sceneId, services } = useEditorStore(
     useShallow((state) => ({
-      bounds: state.boundingBox,
+      bounds: state.selectedConfig.boundingBox,
       sceneId: state.sceneId,
       services: state.services
     }))

--- a/app/pages/editor-page.tsx
+++ b/app/pages/editor-page.tsx
@@ -23,8 +23,8 @@ export function EditorPage() {
   const { storedSceneId, collectionId, temporalRange } = useEditorStore(
     useShallow((state) => ({
       storedSceneId: state.sceneId,
-      collectionId: state.collectionId,
-      temporalRange: state.temporalRange
+      collectionId: state.selectedConfig.collectionId,
+      temporalRange: state.selectedConfig.temporalRange
     }))
   );
 

--- a/app/stores/editor-store.ts
+++ b/app/stores/editor-store.ts
@@ -5,26 +5,24 @@ import type { ServiceInfo } from '$types';
 
 type BoundingBox = [number, number, number, number];
 
-type EditorState = {
-  code: string;
-  hasCodeChanged: boolean;
+type ConfigValues = {
   collectionId: string;
   temporalRange: [string, string];
   cloudCover: number;
   selectedBands: string[];
   boundingBox?: BoundingBox;
+};
+
+type EditorState = {
+  code: string;
+  hasCodeChanged: boolean;
+  selectedConfig: ConfigValues;
+  previousConfig: ConfigValues;
   services: ServiceInfo[];
   sceneId: string | null;
 };
 
-type ResetDefaults = Pick<
-  EditorState,
-  | 'collectionId'
-  | 'cloudCover'
-  | 'temporalRange'
-  | 'selectedBands'
-  | 'boundingBox'
->;
+type ResetDefaults = Partial<ConfigValues>;
 
 type EditorActions = {
   setCode: (code: string) => void;
@@ -55,29 +53,52 @@ type EditorActions = {
 
 type EditorStore = EditorState & EditorActions;
 
-const initialState: EditorState = {
-  code: '',
-  hasCodeChanged: false,
+// Helper to create initial config with defaults
+const createInitialConfig = (
+  overrides: Partial<ConfigValues> = {}
+): ConfigValues => ({
   collectionId: 'sentinel-2-l2a',
   temporalRange: ['', ''],
   cloudCover: 50,
   selectedBands: [],
   boundingBox: undefined,
-  services: [],
-  sceneId: null
-};
+  ...overrides
+});
 
 export const useEditorStore = create<EditorStore>()(
   persist(
     (set) => ({
-      ...initialState,
+      code: '',
+      hasCodeChanged: false,
+      selectedConfig: createInitialConfig(),
+      previousConfig: createInitialConfig(),
+      services: [],
+      sceneId: null,
       setCode: (code) => set({ code, hasCodeChanged: true }),
       setHasCodeChanged: (changed) => set({ hasCodeChanged: changed }),
-      setCollectionId: (collectionId) => set({ collectionId, services: [] }),
-      setTemporalRange: (temporalRange) => set({ temporalRange, services: [] }),
-      setCloudCover: (cloudCover) => set({ cloudCover, services: [] }),
-      setSelectedBands: (selectedBands) => set({ selectedBands }),
-      setBoundingBox: (boundingBox) => set({ boundingBox }),
+      setCollectionId: (collectionId) =>
+        set((state) => ({
+          selectedConfig: { ...state.selectedConfig, collectionId },
+          services: []
+        })),
+      setTemporalRange: (temporalRange) =>
+        set((state) => ({
+          selectedConfig: { ...state.selectedConfig, temporalRange },
+          services: []
+        })),
+      setCloudCover: (cloudCover) =>
+        set((state) => ({
+          selectedConfig: { ...state.selectedConfig, cloudCover },
+          services: []
+        })),
+      setSelectedBands: (selectedBands) =>
+        set((state) => ({
+          selectedConfig: { ...state.selectedConfig, selectedBands }
+        })),
+      setBoundingBox: (boundingBox) =>
+        set((state) => ({
+          selectedConfig: { ...state.selectedConfig, boundingBox }
+        })),
       setServices: (services) => set({ services, hasCodeChanged: false }),
       toggleServiceVisibility: (serviceId) =>
         set((state) => ({
@@ -89,37 +110,52 @@ export const useEditorStore = create<EditorStore>()(
         })),
       clearServices: () => set({ services: [] }),
       setSceneId: (sceneId) => set({ sceneId }),
-      resetToDefaults: (defaults) =>
+      resetToDefaults: (defaults) => {
+        const newConfig = createInitialConfig(defaults);
         set({
-          ...initialState,
-          ...defaults,
+          code: '',
           hasCodeChanged: false,
+          selectedConfig: newConfig,
+          previousConfig: newConfig,
           services: []
-        }),
-      clearEditor: () => set({ ...initialState }),
-      hydrateFromScene: (sceneId, scene) =>
+        });
+      },
+      clearEditor: () => {
+        const initialConfig = createInitialConfig();
         set({
-          sceneId,
+          code: '',
+          hasCodeChanged: false,
+          selectedConfig: initialConfig,
+          previousConfig: initialConfig,
+          services: [],
+          sceneId: null
+        });
+      },
+      hydrateFromScene: (sceneId, scene) => {
+        const sceneConfig = createInitialConfig({
           collectionId: scene.collectionId,
           temporalRange: scene.temporalRange,
           cloudCover: scene.cloudCover,
           selectedBands: scene.defaultBands,
-          boundingBox: scene.boundingBox,
+          boundingBox: scene.boundingBox
+        });
+        set({
+          sceneId,
+          selectedConfig: sceneConfig,
+          previousConfig: sceneConfig,
           code: scene.suggestedAlgorithm || '',
           hasCodeChanged: false,
           services: []
-        })
+        });
+      }
     }),
     {
       name: 'openeo-editor-storage',
       storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         code: state.code,
-        collectionId: state.collectionId,
-        temporalRange: state.temporalRange,
-        cloudCover: state.cloudCover,
-        selectedBands: state.selectedBands,
-        boundingBox: state.boundingBox,
+        selectedConfig: state.selectedConfig,
+        previousConfig: state.previousConfig,
         sceneId: state.sceneId
       })
     }

--- a/test/integration/auth.spec.ts
+++ b/test/integration/auth.spec.ts
@@ -100,7 +100,7 @@ test.describe('Authenticated UI', () => {
     });
     await expect(
       applyButton,
-      'Apply button should be initally disabled'
+      'Apply button should be initially disabled'
     ).toBeDisabled();
 
     // Switch to code tab and change code to enable Apply
@@ -118,6 +118,43 @@ test.describe('Authenticated UI', () => {
     await expect(
       applyButton,
       'Apply button should be enabled after code change when authenticated and ready'
+    ).toBeEnabled();
+  });
+
+  test('should enable Apply button after config change', async ({
+    authenticatedPage
+  }) => {
+    await authenticatedPage.goto('/editor/sentinel-2-apa');
+
+    const applyButton = authenticatedPage.getByRole('button', {
+      name: /apply/i
+    });
+    await expect(
+      applyButton,
+      'Apply button should be initially disabled'
+    ).toBeDisabled();
+
+    // Switch to configuration tab and change cloud cover
+    const configTab = authenticatedPage.getByRole('tab', {
+      name: /configuration/i
+    });
+    await configTab.click();
+    await expect(configTab).toHaveAttribute('aria-selected', 'true');
+
+    // Change the temporal range
+    const startDateInput = authenticatedPage
+      .locator('input[type="date"]')
+      .first();
+    await expect(startDateInput).toBeVisible({ timeout: 10000 });
+    await startDateInput.fill('2025-05-02');
+    // Manually dispatch change event to ensure React onChange fires
+    await startDateInput.evaluate((el: HTMLInputElement) => {
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await expect(
+      applyButton,
+      'Apply button should be enabled after config change when authenticated'
     ).toBeEnabled();
   });
 });

--- a/test/integration/navigation.spec.ts
+++ b/test/integration/navigation.spec.ts
@@ -59,7 +59,7 @@ test.describe('Navigation', () => {
       await page.waitForURL('/docs');
 
       // Navigate home
-      await page.getByRole('link', { name: 'Home' }).click();
+      await page.getByRole('link', { name: 'Home', exact: true }).click();
       await expect(page).toHaveURL('/');
     });
 


### PR DESCRIPTION
## What I changed
- Refactor editor store config into selectedConfig and previousConfig
to make change detection explicit and easier to reason about.
- Update editor, header, map, and page selectors to read nested config
fields from the new store shape.
- Enable Apply when either code or configuration changed by passing a
new hasConfigChanged flag through EditorPanel to EditorToolbar.
- Add integration test coverage for enabling Apply after configuration
changes in authenticated editor flow.
- Fix unrelated test that is currently failing on main

## How to test it
1. Load a selected scene -> apply button is disabled and service created
2. Change the config (i.e. update dates) -> apply button is enabled
3. Apply the changes -> apply button is disabled again and service created

Issue described in https://github.com/developmentseed/openeo-studio/issues/56