### PR TITLE
fix(pyodide): pin openeo < 0.50 to avoid geopandas dep failure

### DIFF
--- a/app/contexts/pyodide-context.tsx
+++ b/app/contexts/pyodide-context.tsx
@@ -47,11 +47,14 @@ async function initializePyodide(
   });
   onLog(createLogEntry('Pyodide loaded successfully', 'success'));
 
-  // Install OpenEO package
+  // Install OpenEO package.
+  // Pinned to <0.50 because openeo 0.50.0 added geopandas as a hard
+  // runtime dependency, which currently fails to resolve in Pyodide.
+  // See https://github.com/developmentseed/openeo-studio/issues/70
   onLog(createLogEntry('Installing openeo package...'));
   await pyodideInstance.loadPackage('micropip');
   const micropip = pyodideInstance.pyimport('micropip');
-  await micropip.install('openeo');
+  await micropip.install('openeo<0.50');
   onLog(createLogEntry('openeo package installed', 'success'));
 
   // Initialize Ruff linter


### PR DESCRIPTION
## Summary

Fixes #70.

The Pyodide environment was failing to initialize at the `Installing openeo package...` step with a `micropip` `add_wheel` traceback.

## Root cause

The [`openeo` 0.50.0 release](https://github.com/Open-EO/openeo-python-client/releases/tag/v0.50.0) promoted `geopandas` from an optional/test extra to a **hard runtime dependency**:

```
'geopandas>=0.14; python_version >= "3.9"',
'geopandas',
```

micropip cannot resolve `geopandas` (and its native `GDAL`/`fiona` deps) in the current Pyodide build, so the entire install fails and the editor never gets a working Python env.

`openeo` 0.49.x only requires `requests`, `urllib3`, `shapely`, `numpy`, `xarray`, `pandas`, `pystac`, `deprecated` — all resolvable in Pyodide.

## Fix

Pin `openeo<0.50` in [`app/contexts/pyodide-context.tsx`](app/contexts/pyodide-context.tsx). We can drop the pin once Pyodide ships a usable `geopandas` build or upstream makes the dependency optional again.

---

_Claude quick fix after analysis._