### PR TITLE
Fix page remount on token renew

### DIFF
--- a/app/components/auth/require-auth.tsx
+++ b/app/components/auth/require-auth.tsx
@@ -7,7 +7,13 @@ import { RestrictedPage } from '$components/auth/restricted-page';
 export function RequireAuth() {
   const { isLoading, isAuthenticated } = useAuth();
 
-  if (isLoading) {
+  // react-oidc-context sets `isLoading` during silent renew (`signinSilent`),
+  // including when the user is already authenticated. Blocking on that unmounts
+  // protected pages and looks like a full refresh. Only block while we do not
+  // yet know the user is signed in.
+  const isBlockingAuthLoad = isLoading && !isAuthenticated;
+
+  if (isBlockingAuthLoad) {
     return (
       <Flex flex={1} alignItems='center' justifyContent='center'>
         <Spinner size='lg' />

--- a/app/components/auth/user-info.tsx
+++ b/app/components/auth/user-info.tsx
@@ -15,8 +15,7 @@ async function hash(string: string) {
 }
 
 export function UserInfo(props: LoginButtonProps) {
-  const { isLoading, isAuthenticated, user, removeUser, events, signinSilent } =
-    useAuth();
+  const { isAuthenticated, user, removeUser } = useAuth();
 
   const profile = user?.profile;
 
@@ -27,19 +26,9 @@ export function UserInfo(props: LoginButtonProps) {
     }
   }, [profile?.email]);
 
-  useEffect(() => {
-    // the `return` is important - addAccessTokenExpiring() returns a cleanup function
-    return events.addAccessTokenExpiring(() => {
-      signinSilent();
-    });
-  }, [events, signinSilent]);
-
-  if (!isAuthenticated || !profile || isLoading) {
+  if (!isAuthenticated || !profile) {
     return <LoginButton {...props} />;
   }
-
-  // const username =
-  //   `${profile.given_name} ${profile.family_name}`.trim() || undefined;
 
   return (
     <Tooltip.Root positioning={{ placement: 'right' }} openDelay={100}>


### PR DESCRIPTION
When a token was renewed, the page would be temporarily unmounted and remounted, resetting the state