### PR TITLE
Fix STAC band parsing for cube dimensions

### DIFF
--- a/app/utils/stac-band-parser.ts
+++ b/app/utils/stac-band-parser.ts
@@ -1,8 +1,14 @@
 /**
  * STAC Band Parsing Utilities
  *
- * Extract band metadata from STAC items for display in the editor.
- * Supports Sentinel-2 L2A reflectance band structure.
+ * Extract band metadata from STAC collections for display in the editor.
+ * Backends publish band info in different, both-valid shapes:
+ *   - summaries.bands: rich per-band objects (seen from the EOPF explorer
+ *     backend) - handled by extractBandsFromSummaries.
+ *   - cube:dimensions.<name>.values on a "bands"-type dimension: a bare
+ *     list of band-name strings (the openEO datacube extension, seen from
+ *     other openEO backends e.g. openeo.ds.io) - handled by
+ *     extractBandsFromCubeDimensions.
  */
 import type { StacCollection } from 'stac-ts';
 
@@ -16,29 +22,20 @@ interface CollectionBand {
   'eo:full_width_half_max'?: number;
 }
 
-/**
- * Extract band variables from a STAC collection's summaries.
- *
- * @param stacCollection - STAC collection containing summaries with band metadata
- * @returns Array of band variables with metadata, or empty array if not found
- *
- * @example
- * ```typescript
- * const bands = extractBandsFromStac(collection);
- * // [
- * //   { name: "b02", label: "Blue", ... },
- * //   { name: "b03", label: "Green", ... }
- * // ]
- * ```
- */
-export function extractBandsFromStac(
-  stacCollection: StacCollection | null | undefined
+interface CubeDimension {
+  type?: string;
+  values?: unknown;
+}
+
+function extractBandsFromSummaries(
+  stacCollection: StacCollection
 ): BandVariable[] {
-  if (!stacCollection?.summaries?.bands) {
+  const summariesBands = stacCollection.summaries?.bands;
+  if (!Array.isArray(summariesBands)) {
     return [];
   }
 
-  const reflectanceBands = stacCollection.summaries.bands as CollectionBand[];
+  const reflectanceBands = summariesBands as CollectionBand[];
   return reflectanceBands.map((band: CollectionBand) => {
     // Extract label from description: "Blue (band 2)" -> "Blue"
     const label = band.description?.match(/^([^(]+)/)?.[1]?.trim() || band.name;
@@ -71,4 +68,60 @@ export function extractBandsFromStac(
       wavelength
     };
   });
+}
+
+function extractBandsFromCubeDimensions(
+  stacCollection: StacCollection
+): BandVariable[] {
+  const dimensions = stacCollection['cube:dimensions'] as
+    | Record<string, CubeDimension>
+    | undefined;
+  const bandsDimension = Object.values(dimensions ?? {}).find(
+    (dim) => dim?.type === 'bands' && Array.isArray(dim.values)
+  );
+  if (!bandsDimension) {
+    return [];
+  }
+
+  return (bandsDimension.values as string[]).map((name) => {
+    // These band names often carry their resolution as a suffix, e.g.
+    // "B04_20m" - pull it out for display, but keep `name` unchanged since
+    // it's the literal identifier openEO process graphs must reference.
+    const resolutionMatch = name.match(/_(\d+m)$/i);
+    return {
+      name,
+      label: resolutionMatch ? name.slice(0, resolutionMatch.index) : name,
+      resolution: resolutionMatch?.[1]
+    };
+  });
+}
+
+/**
+ * Extract band variables from a STAC collection.
+ *
+ * @param stacCollection - STAC collection containing band metadata
+ * @returns Array of band variables with metadata, or empty array if not found
+ *
+ * @example
+ * ```typescript
+ * const bands = extractBandsFromStac(collection);
+ * // [
+ * //   { name: "b02", label: "Blue", ... },
+ * //   { name: "b03", label: "Green", ... }
+ * // ]
+ * ```
+ */
+export function extractBandsFromStac(
+  stacCollection: StacCollection | null | undefined
+): BandVariable[] {
+  if (!stacCollection) {
+    return [];
+  }
+
+  const summaryBands = extractBandsFromSummaries(stacCollection);
+  if (summaryBands.length > 0) {
+    return summaryBands;
+  }
+
+  return extractBandsFromCubeDimensions(stacCollection);
 }

--- a/test/utils/stac-band-parser.test.ts
+++ b/test/utils/stac-band-parser.test.ts
@@ -1,0 +1,96 @@
+import type { StacCollection } from 'stac-ts';
+
+import { extractBandsFromStac } from '$utils/stac-band-parser';
+
+describe('extractBandsFromStac', () => {
+  it('returns an empty array when the collection is null/undefined', () => {
+    expect(extractBandsFromStac(null)).toEqual([]);
+    expect(extractBandsFromStac(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array when neither summaries.bands nor a bands cube:dimension is present', () => {
+    const collection = { summaries: { gsd: [10] } } as unknown as StacCollection;
+    expect(extractBandsFromStac(collection)).toEqual([]);
+  });
+
+  describe('summaries.bands shape (e.g. EOPF explorer backend)', () => {
+    const collection = {
+      summaries: {
+        bands: [
+          {
+            name: 'reflectance|b02',
+            description: 'Blue (band 2)',
+            'eo:common_name': 'blue',
+            'eo:center_wavelength': 0.49
+          },
+          {
+            name: 'b8a',
+            description: 'Narrow NIR (band 8a)'
+          }
+        ]
+      }
+    } as unknown as StacCollection;
+
+    it('parses label, wavelength and resolution from band metadata', () => {
+      const bands = extractBandsFromStac(collection);
+      expect(bands).toEqual([
+        {
+          name: 'reflectance|b02',
+          label: 'Blue',
+          commonName: 'blue',
+          resolution: '10m',
+          wavelength: '490 nm'
+        },
+        {
+          name: 'b8a',
+          label: 'Narrow NIR',
+          commonName: undefined,
+          resolution: '20m',
+          wavelength: undefined
+        }
+      ]);
+    });
+  });
+
+  describe('cube:dimensions bands shape (e.g. openeo.ds.io backend)', () => {
+    const collection = {
+      'cube:dimensions': {
+        x: { type: 'spatial', axis: 'x' },
+        t: { type: 'temporal' },
+        spectral: {
+          type: 'bands',
+          values: ['B04_20m', 'B02_10m', 'SCL_60m', 'Product']
+        }
+      }
+    } as unknown as StacCollection;
+
+    it('falls back to the bands-type cube:dimensions entry', () => {
+      const bands = extractBandsFromStac(collection);
+      expect(bands).toEqual([
+        { name: 'B04_20m', label: 'B04', resolution: '20m' },
+        { name: 'B02_10m', label: 'B02', resolution: '10m' },
+        { name: 'SCL_60m', label: 'SCL', resolution: '60m' },
+        { name: 'Product', label: 'Product', resolution: undefined }
+      ]);
+    });
+
+    it('keeps the full raw name so process graphs reference a valid band identifier', () => {
+      const bands = extractBandsFromStac(collection);
+      expect(bands.map((b) => b.name)).toContain('B04_20m');
+    });
+  });
+
+  it('prefers summaries.bands over cube:dimensions when both are present', () => {
+    const collection = {
+      summaries: {
+        bands: [{ name: 'b02', description: 'Blue' }]
+      },
+      'cube:dimensions': {
+        spectral: { type: 'bands', values: ['B04_20m'] }
+      }
+    } as unknown as StacCollection;
+
+    const bands = extractBandsFromStac(collection);
+    expect(bands.map((b) => b.name)).toEqual(['b02']);
+  });
+});


### PR DESCRIPTION
Backends publish band info in different STAC shapes. The EOPF explorer backend uses summaries.bands (rich per-band objects), but other openEO backends (e.g. openeo.ds.io) only expose bands via the datacube extension's cube:dimensions - a "bands"-type dimension with a bare list of band-name strings (e.g. "B04_20m"). extractBandsFromStac only checked summaries.bands, so the configuration tab showed "The parser could not find suitable bands" for any collection using the latter shape, even though the data was there.

Confirmed against the live collection at https://openeo.ds.io/collections/sentinel-2-l2a, which has no summaries.bands but does have a bands-type cube:dimensions entry.
